### PR TITLE
Make default listener non-ssl

### DIFF
--- a/scripts/cloudflow.nginx.conf
+++ b/scripts/cloudflow.nginx.conf
@@ -1,12 +1,14 @@
 server {
-    listen       [::]:8000 ssl ipv6only=off;
+    listen       [::]:8000 ipv6only=off;
+    
     server_name  localhost;
 
     # to enable https, uncomment the following lines, and point to your cert and key files
     #
     #ssl_certificate /etc/nginx/ssl/nginx.crt;
     #ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+    #listen       [::]:8001 ssl ipv6only=off;
+    
     # For custom log, uncomment the following line and set the desired path of the log file
     #
     #access_log  /var/log/nginx/cloudflow.access.log  main;


### PR DESCRIPTION
It greatly helps first steps if the default configuration works out of box for locally running, non-authenticated Mistrals,