### PR TITLE
WIP: Support of task execution's started_at and finished_at

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 Since CloudFlow doesn't have any backend services, it must connect to a live Mistral instance.
 
 #### Mistral Instance
-Thankfully, Mistral can be easily spawned [as a docker container](https://github.com/openstack/mistral/blob/master/tools/docker/DOCKER_README.rst "as a docker container"), or you can use any Mistral instance you have. (Mistral version must be >= Pike).
+Thankfully, Mistral can be easily spawned [as a docker container](https://github.com/openstack/mistral/blob/master/tools/docker/DOCKER_README.rst "as a docker container"), or you can use any Mistral instance you have. (Mistral version must be >= Stein).
 
 |  Tip |
 | :------------ |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.4 as builder
+FROM node:8.15.1 as builder
 
 LABEL name="CloudFlow" \
       version="0.6.3" \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ CloudFlow requires Mistral **Pike** or greater, as we rely on
 new [runtime_context](https://docs.openstack.org/developer/mistral/developer/webapi/v2.html#tasks)
 added to Mistral Pike.
 
+| Mistral Version  | CloudFlow Version to use                                        |
+|------------------|-----------------------------------------------------------------|
+| Stein (or newer) | Latest stable                                                   |
+| Pike - Rocky     | [0.6.4](https://github.com/nokia/CloudFlow/releases/tag/v0.6.4) |
+
     
 ## Installing CloudFlow on the Mistral machine
 CloudFlow has no dedicated backend service and passes the API calls to Mistral

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CloudFlow",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "private": true,
   "engines": {

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,7 +1,7 @@
 <div class="modal-header">
   <h4 class="modal-title">
     <img src="assets/icon256.svg" height="32" width="32" class="mr-2" />
-    CloudFlow <small class="text-muted">v0.6.4</small>
+    CloudFlow <small class="text-muted">v0.7.0</small>
   </h4>
   <button type="button" class="close" aria-label="Close" (click)="modal.dismiss('')">
     <span aria-hidden="true">&times;</span>

--- a/src/app/engines/mistral/mistral.service.ts
+++ b/src/app/engines/mistral/mistral.service.ts
@@ -66,7 +66,7 @@ export class MistralService {
      */
     executionTasks(id: string): Observable<TaskExec[]> {
         const fields = ["state_info", "created_at", "name", "runtime_context", "workflow_name", "state",
-            "updated_at", "workflow_execution_id", "workflow_id", "type"].join(",");
+            "updated_at", "workflow_execution_id", "workflow_id", "type", "started_at", "finished_at"].join(",");
         const params = toUrlParams({fields});
 
         return this.http.get(this.prefix + `executions/${id}/tasks`, {params})

--- a/src/app/executions/task-info/task-info.component.html
+++ b/src/app/executions/task-info/task-info.component.html
@@ -51,14 +51,28 @@
 
     <div class="d-flex flex-row">
 
-      <!-- created -->
-      <cf-info-item class="flex-1-1-auto" [prop]="properties['created_at']"></cf-info-item>
+      <!-- started -->
+      <cf-info-item class="flex-1-1-33" [prop]="properties['started_at']"></cf-info-item>
 
-      <!-- updated -->
-      <cf-info-item class="flex-1-1-auto" [prop]="properties['updated_at']"></cf-info-item>
+      <!-- finished -->
+      <cf-info-item class="flex-1-1-33" [prop]="properties['finished_at']"></cf-info-item>
 
       <!-- duration -->
-      <cf-info-item class="flex-1-1-auto" [prop]="properties['duration']"></cf-info-item>
+      <cf-info-item class="flex-1-1-33" [prop]="properties['duration']"></cf-info-item>
+
+    </div>
+
+    <div class="d-flex flex-row">
+
+      <!-- created -->
+      <cf-info-item class="flex-1-1-33" [prop]="properties['created_at']"></cf-info-item>
+
+      <!-- updated -->
+      <cf-info-item class="flex-1-1-33" [prop]="properties['updated_at']"></cf-info-item>
+
+      <!-- total duration -->
+      <cf-info-item class="flex-1-1-33" [prop]="properties['durationTotal']"></cf-info-item>
+
     </div>
 
     <!-- with-items -->

--- a/src/app/executions/task-info/task-info.component.ts
+++ b/src/app/executions/task-info/task-info.component.ts
@@ -28,7 +28,10 @@ export class TaskInfoComponent implements OnInit, OnDestroy {
         {key: 'state_info', display: 'State Info', renderType: 'code', mode: 'text', instance: 'taskExec'},
         {key: 'created_at', display: 'Created', instance: 'taskExec'},
         {key: 'updated_at', display: 'Updated', instance: 'taskExec'},
+        {key: 'started_at', display: 'Started', instance: 'taskExec'},
+        {key: 'finished_at', display: 'Finished', instance: 'taskExec'},
         {key: 'duration', display: 'Duration', instance: 'taskExec'},
+        {key: 'durationTotal', display: 'Total', instance: 'taskExec'},
         {key: 'with-items', display: 'With Items', instance: 'taskDef'},
         {key: 'result', display: 'Result', renderType: 'code', mode: 'json', instance: 'taskExec'},
         {key: 'published', display: 'Published', renderType: 'code', mode: 'json', instance: 'taskExec'}

--- a/src/app/executions/tasks-runtime/tasks-runtime.component.html
+++ b/src/app/executions/tasks-runtime/tasks-runtime.component.html
@@ -8,7 +8,7 @@
     <thead>
     <tr>
       <th><input type="search" class="form-control form-control-sm" placeholder="Filter by task name or ID" [(ngModel)]="filter" /></th>
-      <th [ngClass]="getSortClass(CREATED_AT_RELATIVE)" (click)="sortBy(CREATED_AT_RELATIVE)">Timespan</th>
+      <th [ngClass]="getSortClass(STARTED_AT_RELATIVE)" (click)="sortBy(STARTED_AT_RELATIVE)">Timespan</th>
       <th [ngClass]="getSortClass(DURATION_SEC)" (click)="sortBy(DURATION_SEC)">Runtime</th>
     </tr>
     </thead>
@@ -24,13 +24,16 @@
 
       <td [ngbPopover]="runtimeTooltip" container="body" triggers="mouseenter:mouseleave">
         <div class="stackedBarChart">
-          <ng-template #runtimeTooltip>Started: {{task.created_at}}<br/>
-            Updated: {{task.updated_at}}<br/>
-            Percent: {{task.duration_sec === 0 ? '< ' : ''}}{{task.barWidth | number}}%</ng-template>
+          <ng-template #runtimeTooltip>Started: {{task.started_at}}<br/>
+            Finished: {{task.finished_at}}<br/>
+            Percent: {{task.duration_sec === 0 ? '< ' : ''}}{{task.runningBarWidth | number}}%<br/>
+            Total: {{task.duration_sec === 0 ? '< ' : ''}}{{task.totalBarWidth | number}}%</ng-template>
 
           <div class="inner">
             <div class="prehighlight" [style.width.%]="task.preBarWidth"></div>
-            <div class="highlight" [style.width.%]="task.barWidth"></div>
+            <div class="waiting highlight" [style.width.%]="task.waitingBeforeBarWidth"></div>
+            <div class="highlight" [style.width.%]="task.runningBarWidth"></div>
+            <div class="waiting highlight" [style.width.%]="task.waitingAfterBarWidth"></div>
           </div>
         </div>
       </td>

--- a/src/app/executions/tasks-runtime/tasks-runtime.component.scss
+++ b/src/app/executions/tasks-runtime/tasks-runtime.component.scss
@@ -13,12 +13,15 @@
     background: #dde4e6;
 
     .highlight {
-      border-radius: 2px;
       transition: filter .3s ease-in-out;
       background-color: $entity-completed;
 
       &:hover {
         filter: brightness(1.1);
+      }
+
+      &.waiting {
+        background-color: $entity-waiting;
       }
     }
 

--- a/src/app/shared/models/taskExec.ts
+++ b/src/app/shared/models/taskExec.ts
@@ -36,15 +36,19 @@ export class TaskExec implements JTaskExec {
     id: string;
     created_at: string;
     updated_at: string;
+    started_at: string;
+    finished_at: string;
     state_info: string;
     result: null | object;
 
     taskDuration: ItemDuration;
+    totalDuration: ItemDuration;
 
     constructor(other: JTaskExec) {
         Object.assign(this, other);
         this.runtime_context = stringToObject(this.runtime_context, "json");
-        this.taskDuration = new ItemDuration(this.created_at, this.updated_at);
+        this.taskDuration = new ItemDuration(this.started_at, this.finished_at);
+        this.totalDuration = new ItemDuration(this.created_at, this.updated_at);
     }
 
     setResult(result: string) {
@@ -65,5 +69,9 @@ export class TaskExec implements JTaskExec {
 
     get duration() {
         return this.taskDuration.duration;
+    }
+
+    get durationTotal() {
+        return this.totalDuration.duration;
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -120,6 +120,10 @@ pre {
   flex: 1 1 0;
 }
 
+.flex-1-1-33 {
+  flex: 1 1 33%;
+}
+
 .flex-center {
   text-align: center;
   display: flex;

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -8,6 +8,7 @@ $entity-success: #458E03;
 $entity-error: #D50501;
 $entity-running: #F39C12;
 $entity-completed: #42A5F5;
+$entity-waiting: #F39C12;
 $background-color: #F3F3F3;
 $border: #E1E1E1;
 $text-muted2: #A0A0A0;


### PR DESCRIPTION
Display task execution's duration, calculated by 2 new fields:
started_at and finished_at, if they exist.

Signed-off-by: Oleg Ovcharuk <vgvoleg@gmail.com>