### PR TITLE
Patch execution if missing input

### DIFF
--- a/src/app/engines/mistral/mistral.service.ts
+++ b/src/app/engines/mistral/mistral.service.ts
@@ -62,6 +62,24 @@ export class MistralService {
     }
 
     /**
+     * This call will patch the "missing" 'input' value on a execution.
+     */
+    patchExecutionData(exec: Execution) {
+        if (exec.input != null) {
+            return ObservableOf(exec);
+        } else {
+            return this.http.get(this.prefix + `executions/${exec.id}/input`)
+                .pipe(
+                    map(res => {
+                        exec.setInput(res["input"]);
+                        return exec;
+                    }),
+                    catchError(e => this.handleError(e))
+                );
+        }
+    }
+
+    /**
      * url: /executions/<id>/tasks
      */
     executionTasks(id: string): Observable<TaskExec[]> {

--- a/src/app/executions/execution/execution.component.ts
+++ b/src/app/executions/execution/execution.component.ts
@@ -95,6 +95,7 @@ export class ExecutionComponent implements AfterViewInit, OnDestroy {
 
         try {
             this.execution = await this.service.execution(this.executionId).toPromise();
+            this.execution = await this.service.patchExecutionData(this.execution).toPromise();
             this.tasks = await this.service.executionTasks(this.executionId).toPromise();
             this.service.setParentExecutionId(this.execution);
         } catch (e) {

--- a/src/app/shared/models/execution.ts
+++ b/src/app/shared/models/execution.ts
@@ -49,4 +49,8 @@ export class Execution implements JExecution {
     get duration() {
         return this.executionDuration.duration;
     }
+
+    setInput(input: string) {
+        this.input = stringToObject(input, "json");
+    }
 }


### PR DESCRIPTION
Mistral Pike didn't return 'input' parameters when we get execution by id: GET /v2/executions/{id}