### PR TITLE
Support Cross Domain Storage Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ create the following `auth.json` file under the `assets/` folder (i.e. `assets/a
 
 You can obtain all the URLs by examining the output of `https://<openid-server-ip>:<port>/auth/realms/<realm>/.well-known/openid-configuration`
 
+#### Cross Domain Access Token Sharing
+
+Redirecting from different applications to the CloudFlow. 
+CloudFlow supports reading `access_token` form authenticated application opened in another tab with the same browser without passing the `access_token` in the URL. 
+
+The authenticated application should allow that by adding the following: 
+
+Adding [cross-domain-storage](https://github.com/MatthewLarner/cross-domain-storage) dependency in the host application: 
+ ```Javascript
+ import createHost from 'cross-domain-storage/host';
+ createHost([{
+   origin: 'CloudFlow URL',
+   allowedMethods: ['get']
+  }]);
+```
+
 ### No Authentication 
 If you want to work w/o authentication, make sure your Mistral does not require authentication to perform REST API
 requests, by setting the following in `/etc/mistral/mistral.conf`:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bootstrap-css-only": "4.1.1",
     "codemirror": "^5.39.0",
     "core-js": "^2.5.7",
+    "cross-domain-storage": "^2.0.4",
     "dagre": "^0.8.4",
     "font-awesome": "^4.7.0",
     "jquery": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,6 +1902,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-domain-storage@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/cross-domain-storage/-/cross-domain-storage-2.0.4.tgz#d8823177d4aa8446ed449d3c3d87fa65528f22b7"
+  integrity sha512-zRiZQeXlUx3tiZMCP+WG7qt6VqTeinQdP04EJ23HqRgWQKwDWVcOeJ33scYY4zSCQd991gwQYLt0l++KKKkAQw==
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"


### PR DESCRIPTION
After Redirecting from authenticated application to the CloudFlow App within the same browser, Without reading the token from the URL. 

CloudFlow will read the access token from the Host application localStorage after redirecting without Passing access token into the URL. 
We are using the concept of [PostMessage ](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to communicate between different domains within the same browser without exposing any sensitive information in the URL. 