### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,8 @@ Also, make sure there is **no** `auth.json` file under the `assets/` directory.
 
 
 ![CloudFlow](docs/main.png "CloudFlow in action")
+
+
+## License
+
+This project is licensed under the Apache-2.0 license - see the [LICENSE](https://github.com/nokia/CloudFlow/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.